### PR TITLE
remove spec.homepage from gemspec

### DIFF
--- a/smart_insight_logging_layout.gemspec
+++ b/smart_insight_logging_layout.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'SmartInsight Logging Layout'
   spec.description   = 'SmartInsight Logging Layout'
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
Email Scheduler Service build failed with:

> The gemspec at /home/rof/cache/bundler/ruby/2.4.0/bundler/gems/smart_insight_logging_layout-cd55c57ca954/smart_insight_logging_layout.gemspec is not valid. Please fix this gemspec.
The validation error was '"TODO: Put your gem's website or public repo URL
here." is not a valid HTTP URI'

Thus it's not filled properly, how about removing it from gemspec (otherwise please give a proper URL for it)?